### PR TITLE
Expand Metal renderer test coverage

### DIFF
--- a/Tests/IRPlayer-swiftTests/IRMetalDistortionMeshTests.swift
+++ b/Tests/IRPlayer-swiftTests/IRMetalDistortionMeshTests.swift
@@ -10,6 +10,13 @@ import XCTest
 
 final class IRMetalDistortionMeshTests: XCTestCase {
 
+    private func makeMetalDevice() throws -> MTLDevice {
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            throw XCTSkip("Metal device unavailable")
+        }
+        return device
+    }
+
     func testBufferByteLengthRejectsInvalidOrOverflowingInputs() {
         XCTAssertNil(IRMetalDistortionMesh.bufferByteLength(elementCount: 0, stride: MemoryLayout<UInt16>.stride))
         XCTAssertNil(IRMetalDistortionMesh.bufferByteLength(elementCount: 1, stride: 0))
@@ -45,5 +52,19 @@ final class IRMetalDistortionMeshTests: XCTestCase {
         XCTAssertEqual(IRMetalDistortionMesh.indexValue(0), IRMetalDistortionMeshPolicy.indexValue(0))
         XCTAssertEqual(IRMetalDistortionMesh.indexValue(Int(UInt16.max)), IRMetalDistortionMeshPolicy.indexValue(Int(UInt16.max)))
         XCTAssertNil(IRMetalDistortionMeshPolicy.indexValue(-1))
+    }
+
+    func testInitBuildsLeftAndRightDistortionMeshes() throws {
+        let device = try makeMetalDevice()
+
+        let left = try XCTUnwrap(IRMetalDistortionMesh(device: device, modelType: .left))
+        let right = try XCTUnwrap(IRMetalDistortionMesh(device: device, modelType: .right))
+
+        XCTAssertEqual(left.indexCount, 3158)
+        XCTAssertEqual(right.indexCount, 3158)
+        XCTAssertGreaterThan(left.vertexBuffer.length, 0)
+        XCTAssertGreaterThan(left.indexBuffer.length, 0)
+        XCTAssertGreaterThan(right.vertexBuffer.length, 0)
+        XCTAssertGreaterThan(right.indexBuffer.length, 0)
     }
 }

--- a/Tests/IRPlayer-swiftTests/IRMetalFisheyeMeshTests.swift
+++ b/Tests/IRPlayer-swiftTests/IRMetalFisheyeMeshTests.swift
@@ -10,6 +10,13 @@ import XCTest
 
 final class IRMetalFisheyeMeshTests: XCTestCase {
 
+    private func makeMetalDevice() throws -> MTLDevice {
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            throw XCTSkip("Metal device unavailable")
+        }
+        return device
+    }
+
     func testBufferByteLengthRejectsInvalidOrOverflowingInputs() {
         XCTAssertNil(IRMetalFisheyeMesh.bufferByteLength(elementCount: 0, stride: MemoryLayout<UInt16>.stride))
         XCTAssertNil(IRMetalFisheyeMesh.bufferByteLength(elementCount: 1, stride: 0))
@@ -100,5 +107,73 @@ final class IRMetalFisheyeMeshTests: XCTestCase {
         XCTAssertEqual(wrapper.centerX, policy.centerX)
         XCTAssertEqual(wrapper.centerY, policy.centerY)
         XCTAssertEqual(wrapper.radius, policy.radius)
+    }
+
+    func testExplicitInitRejectsMismatchedOrEmptyGeometry() throws {
+        let device = try makeMetalDevice()
+
+        XCTAssertNil(IRMetalFisheyeMesh(device: device,
+                                        positions: [SIMD3<Float>(0, 0, 0)],
+                                        texcoords: [],
+                                        indices: [0]))
+        XCTAssertNil(IRMetalFisheyeMesh(device: device,
+                                        positions: [],
+                                        texcoords: [],
+                                        indices: [0]))
+        XCTAssertNil(IRMetalFisheyeMesh(device: device,
+                                        positions: [SIMD3<Float>(0, 0, 0)],
+                                        texcoords: [SIMD2<Float>(0, 0)],
+                                        indices: []))
+    }
+
+    func testExplicitInitBuildsBuffersForValidGeometry() throws {
+        let device = try makeMetalDevice()
+
+        let mesh = try XCTUnwrap(
+            IRMetalFisheyeMesh(device: device,
+                               positions: [
+                                SIMD3<Float>(-1, -1, 0),
+                                SIMD3<Float>(1, -1, 0),
+                                SIMD3<Float>(0, 1, 0)
+                               ],
+                               texcoords: [
+                                SIMD2<Float>(0, 0),
+                                SIMD2<Float>(1, 0),
+                                SIMD2<Float>(0.5, 1)
+                               ],
+                               indices: [0, 1, 2])
+        )
+
+        XCTAssertEqual(mesh.indexCount, 3)
+        XCTAssertGreaterThan(mesh.vertexBuffer.length, 0)
+        XCTAssertGreaterThan(mesh.indexBuffer.length, 0)
+    }
+
+    func testTextureGeometryInitRejectsInvalidResolvedParams() throws {
+        let device = try makeMetalDevice()
+
+        XCTAssertNil(IRMetalFisheyeMesh(device: device,
+                                        textureWidth: 0,
+                                        textureHeight: 100,
+                                        centerX: 50,
+                                        centerY: 50,
+                                        radius: 20))
+    }
+
+    func testTextureGeometryInitBuildsSphereMesh() throws {
+        let device = try makeMetalDevice()
+
+        let mesh = try XCTUnwrap(
+            IRMetalFisheyeMesh(device: device,
+                               textureWidth: 200,
+                               textureHeight: 100,
+                               centerX: 100,
+                               centerY: 50,
+                               radius: 40)
+        )
+
+        XCTAssertEqual(mesh.indexCount, 194400)
+        XCTAssertGreaterThan(mesh.vertexBuffer.length, 0)
+        XCTAssertGreaterThan(mesh.indexBuffer.length, 0)
     }
 }

--- a/Tests/IRPlayer-swiftTests/IRMetalRendererPixelFormatTests.swift
+++ b/Tests/IRPlayer-swiftTests/IRMetalRendererPixelFormatTests.swift
@@ -43,6 +43,15 @@ final class IRMetalRendererPixelFormatTests: XCTestCase {
             throw XCTSkip("Offscreen Metal encoder unavailable")
         }
 
+        guard let vertexBuffer = renderer.vertexBuffer else {
+            throw XCTSkip("Metal vertex buffer unavailable")
+        }
+        encoder.setVertexBuffer(vertexBuffer, offset: 0, index: 0)
+        var scaleVector = SIMD2<Float>(repeating: 1)
+        encoder.setVertexBytes(&scaleVector, length: MemoryLayout<SIMD2<Float>>.size, index: 1)
+        var translationVector = SIMD2<Float>(repeating: 0)
+        encoder.setVertexBytes(&translationVector, length: MemoryLayout<SIMD2<Float>>.size, index: 2)
+
         try body(encoder)
         encoder.endEncoding()
         commandBuffer.commit()

--- a/Tests/IRPlayer-swiftTests/IRMetalRendererPixelFormatTests.swift
+++ b/Tests/IRPlayer-swiftTests/IRMetalRendererPixelFormatTests.swift
@@ -11,6 +11,55 @@ import XCTest
 
 final class IRMetalRendererPixelFormatTests: XCTestCase {
 
+    private func makeRenderer() throws -> IRMetalRenderer {
+        guard let device = MTLCreateSystemDefaultDevice(),
+              let renderer = IRMetalRenderer(device: device) else {
+            throw XCTSkip("Metal device unavailable")
+        }
+        return renderer
+    }
+
+    private func withOffscreenEncoder(
+        renderer: IRMetalRenderer,
+        _ body: (MTLRenderCommandEncoder) throws -> Void
+    ) throws {
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm,
+            width: 2,
+            height: 2,
+            mipmapped: false
+        )
+        descriptor.usage = [.renderTarget, .shaderRead]
+        guard let texture = renderer.device.makeTexture(descriptor: descriptor),
+              let commandBuffer = renderer.commandQueue.makeCommandBuffer() else {
+            throw XCTSkip("Offscreen Metal rendering unavailable")
+        }
+
+        let renderPass = MTLRenderPassDescriptor()
+        renderPass.colorAttachments[0].texture = texture
+        renderPass.colorAttachments[0].loadAction = .clear
+        renderPass.colorAttachments[0].storeAction = .store
+        guard let encoder = commandBuffer.makeRenderCommandEncoder(descriptor: renderPass) else {
+            throw XCTSkip("Offscreen Metal encoder unavailable")
+        }
+
+        try body(encoder)
+        encoder.endEncoding()
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+    }
+
+    private func makeRGBFrame(width: Int = 2, height: Int = 2) -> IRVideoFrameRGB {
+        let bytesPerRow = width * 4
+        let frame = IRVideoFrameRGB(
+            linesize: UInt(bytesPerRow),
+            rgb: Data(repeating: 0xff, count: bytesPerRow * height)
+        )
+        frame.width = width
+        frame.height = height
+        return frame
+    }
+
     func testRuntimeDebugOutputIsSilentByDefault() {
         XCTAssertFalse(IRMetalRuntimeDebugOutput.isEnabled)
 
@@ -200,14 +249,144 @@ final class IRMetalRendererPixelFormatTests: XCTestCase {
     }
 
     func testMakeRGBTextureRejectsLinesizeThatCannotFitBytesPerRow() throws {
-        guard let device = MTLCreateSystemDefaultDevice(),
-              let renderer = IRMetalRenderer(device: device) else {
-            throw XCTSkip("Metal device unavailable")
-        }
+        let renderer = try makeRenderer()
         let frame = IRVideoFrameRGB(linesize: UInt(Int.max) + 1, rgb: Data([0, 0, 0, 0]))
         frame.width = 1
         frame.height = 1
 
         XCTAssertNil(renderer.makeRGBTexture(from: frame))
+    }
+
+    func testMakeRGBTextureCreatesBGRATextureForValidFrame() throws {
+        let renderer = try makeRenderer()
+        let texture = renderer.makeRGBTexture(from: makeRGBFrame())
+
+        XCTAssertEqual(texture?.width, 2)
+        XCTAssertEqual(texture?.height, 2)
+        XCTAssertEqual(texture?.pixelFormat, .bgra8Unorm)
+    }
+
+    func testMakeTextureRejectsInvalidSizeAndCreatesValidTexture() throws {
+        let renderer = try makeRenderer()
+        var bytes = [UInt8](repeating: 0x7f, count: 4)
+
+        bytes.withUnsafeMutableBytes { buffer in
+            XCTAssertNil(renderer.makeTexture(width: 0,
+                                              height: 1,
+                                              pixelFormat: .r8Unorm,
+                                              bytes: buffer.baseAddress!))
+
+            let texture = renderer.makeTexture(width: 2,
+                                               height: 2,
+                                               pixelFormat: .r8Unorm,
+                                               bytes: buffer.baseAddress!)
+            XCTAssertEqual(texture?.width, 2)
+            XCTAssertEqual(texture?.height, 2)
+            XCTAssertEqual(texture?.pixelFormat, .r8Unorm)
+        }
+    }
+
+    func testPixelRendererSelectionMatchesFrameTypes() throws {
+        let renderer = try makeRenderer()
+        var pixelBuffer: CVPixelBuffer?
+        CVPixelBufferCreate(kCFAllocatorDefault,
+                            2,
+                            2,
+                            kCVPixelFormatType_32BGRA,
+                            nil,
+                            &pixelBuffer)
+        let cvFrame = IRFFCVYUVVideoFrame(pixelBuffer: try XCTUnwrap(pixelBuffer))
+
+        XCTAssertTrue(renderer.pixelRenderer(for: cvFrame) is IRMetalPixelRendererNV12)
+        XCTAssertTrue(renderer.pixelRenderer(for: IRFFAVYUVVideoFrame()) is IRMetalPixelRendererI420)
+        XCTAssertTrue(renderer.pixelRenderer(for: makeRGBFrame()) is IRMetalPixelRendererRGB)
+        XCTAssertNil(renderer.pixelRenderer(for: IRFFVideoFrame()))
+    }
+
+    func testRenderRGBDrawsValidFrameToOffscreenEncoder() throws {
+        let renderer = try makeRenderer()
+        guard renderer.pipelineRGB != nil else {
+            throw XCTSkip("RGB Metal pipeline unavailable")
+        }
+
+        try withOffscreenEncoder(renderer: renderer) { encoder in
+            XCTAssertTrue(renderer.renderRGB(rgbFrame: makeRGBFrame(), encoder: encoder))
+        }
+    }
+
+    func testRGBPixelRendererRenders2DAndRejectsMesh() throws {
+        let renderer = try makeRenderer()
+        guard renderer.pipelineRGB != nil else {
+            throw XCTSkip("RGB Metal pipeline unavailable")
+        }
+        let pixelRenderer = IRMetalPixelRendererRGB()
+        let frame = makeRGBFrame()
+
+        try withOffscreenEncoder(renderer: renderer) { encoder in
+            XCTAssertTrue(pixelRenderer.render2D(renderer: renderer, frame: frame, encoder: encoder))
+            XCTAssertFalse(pixelRenderer.renderMesh(renderer: renderer,
+                                                    frame: frame,
+                                                    encoder: encoder,
+                                                    indexCount: 0,
+                                                    indexBuffer: renderer.vertexBuffer!))
+        }
+    }
+
+    func testRGBPixelRendererRejectsRenderingWhenPipelineIsMissing() throws {
+        let renderer = try makeRenderer()
+        renderer.pipelineRGB = nil
+        let pixelRenderer = IRMetalPixelRendererRGB()
+        let frame = makeRGBFrame()
+
+        try withOffscreenEncoder(renderer: renderer) { encoder in
+            XCTAssertFalse(renderer.renderRGB(rgbFrame: frame, encoder: encoder))
+            XCTAssertFalse(pixelRenderer.render2D(renderer: renderer, frame: frame, encoder: encoder))
+            XCTAssertFalse(pixelRenderer.renderMesh(renderer: renderer,
+                                                    frame: frame,
+                                                    encoder: encoder,
+                                                    indexCount: 0,
+                                                    indexBuffer: renderer.vertexBuffer!))
+        }
+    }
+
+    func testPixelRenderersRejectMismatchedFrameTypes() throws {
+        let renderer = try makeRenderer()
+        let nv12Renderer = IRMetalPixelRendererNV12()
+        let i420Renderer = IRMetalPixelRendererI420()
+        let rgbFrame = makeRGBFrame()
+        let params = IRMetalRenderer.Fish2PanoParams(
+            fishwidth: 2,
+            fishheight: 2,
+            panowidth: 2,
+            panoheight: 2,
+            antialias: 0,
+            offsetX: 0
+        )
+
+        try withOffscreenEncoder(renderer: renderer) { encoder in
+            XCTAssertFalse(nv12Renderer.render2D(renderer: renderer, frame: rgbFrame, encoder: encoder))
+            XCTAssertFalse(nv12Renderer.renderMesh(renderer: renderer,
+                                                   frame: rgbFrame,
+                                                   encoder: encoder,
+                                                   indexCount: 0,
+                                                   indexBuffer: renderer.vertexBuffer!))
+            XCTAssertFalse(nv12Renderer.renderFish2Pano(renderer: renderer,
+                                                        frame: rgbFrame,
+                                                        encoder: encoder,
+                                                        params: params,
+                                                        texUVTextures: []))
+
+            XCTAssertFalse(i420Renderer.render2D(renderer: renderer, frame: rgbFrame, encoder: encoder))
+            XCTAssertFalse(i420Renderer.renderMesh(renderer: renderer,
+                                                   frame: rgbFrame,
+                                                   encoder: encoder,
+                                                   indexCount: 0,
+                                                   indexBuffer: renderer.vertexBuffer!))
+            XCTAssertFalse(i420Renderer.renderFish2Pano(renderer: renderer,
+                                                        frame: rgbFrame,
+                                                        encoder: encoder,
+                                                        params: params,
+                                                        texUVTextures: []))
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add offscreen Metal test helpers for renderer coverage
- Cover RGB texture creation, generic Metal texture creation, pixel renderer selection, and renderer early-return paths
- Add stable mismatched-frame tests for NV12/I420/RGB pixel renderers

## Verification
- xcodebuild test -project IRPlayer-swift.xcodeproj -scheme IRPlayer-swift -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IRPlayer-swiftTests/IRMetalRendererPixelFormatTests
- xcodebuild test -project IRPlayer-swift.xcodeproj -scheme IRPlayer-swift -destination 'platform=iOS Simulator,name=iPhone 17' -enableCodeCoverage YES -resultBundlePath /tmp/IRPlayerCoverage.xcresult

Full coverage run: 529 tests, 2 skipped, 0 failures.