### PR TITLE
Expand audio manager test coverage

### DIFF
--- a/Tests/IRPlayer-swiftTests/IRAudioManagerRenderTests.swift
+++ b/Tests/IRPlayer-swiftTests/IRAudioManagerRenderTests.swift
@@ -11,6 +11,21 @@ import XCTest
 
 final class IRAudioManagerRenderTests: XCTestCase {
 
+    func testUnregisteredManagerUsesFallbackStateAndIgnoresPlaybackControls() {
+        let manager = IRAudioManager()
+        let delegate = RecordingAudioManagerDelegate()
+
+        manager.volume = 0.25
+        manager.play(withDelegate: delegate)
+        manager.pause()
+
+        XCTAssertEqual(manager.volume, 1.0)
+        XCTAssertFalse(manager.playing)
+        XCTAssertTrue(manager.delegate === delegate)
+        XCTAssertGreaterThanOrEqual(manager.samplingRate, 0)
+        XCTAssertGreaterThanOrEqual(manager.numberOfChannels, 0)
+    }
+
     func testRegisterAudioSessionDoesNotPrintDebugDiagnostics() {
         let manager = IRAudioManager()
         var setupCallCount = 0
@@ -99,5 +114,16 @@ final class IRAudioManagerRenderTests: XCTestCase {
         default:
             XCTFail("Missing audio unit should fail for wrapper and policy")
         }
+    }
+}
+
+private final class RecordingAudioManagerDelegate: IRAudioManagerDelegate {
+    private(set) var renderCallCount = 0
+
+    func audioManager(_ audioManager: IRAudioManager,
+                      outputData: UnsafeMutablePointer<Float>,
+                      numberOfFrames: UInt32,
+                      numberOfChannels: UInt32) {
+        renderCallCount += 1
     }
 }

--- a/Tests/IRPlayer-swiftTests/IRAudioManagerTests.swift
+++ b/Tests/IRPlayer-swiftTests/IRAudioManagerTests.swift
@@ -11,6 +11,95 @@ import XCTest
 
 final class IRAudioManagerNotificationTests: XCTestCase {
 
+    func testAudioSessionInterruptionNotificationCallsHandlerWithMappedTypeAndOption() {
+        let manager = IRAudioManager()
+        let target = NSObject()
+        var received: [(type: IRAudioManagerInterruptionType, option: IRAudioManagerInterruptionOption)] = []
+        manager.setHandlerTarget(target, interruption: { handlerTarget, _, type, option in
+            XCTAssertTrue(handlerTarget === target)
+            received.append((type, option))
+        }, routeChange: { _, _, _ in
+            XCTFail("Route change handler should not be called for interruption notifications")
+        })
+
+        NotificationCenter.default.post(
+            name: AVAudioSession.interruptionNotification,
+            object: nil,
+            userInfo: [
+                AVAudioSessionInterruptionTypeKey: AVAudioSession.InterruptionType.began.rawValue
+            ]
+        )
+        NotificationCenter.default.post(
+            name: AVAudioSession.interruptionNotification,
+            object: nil,
+            userInfo: [
+                AVAudioSessionInterruptionTypeKey: AVAudioSession.InterruptionType.ended.rawValue,
+                AVAudioSessionInterruptionOptionKey: AVAudioSession.InterruptionOptions.shouldResume.rawValue
+            ]
+        )
+
+        XCTAssertEqual(received.map(\.type), [.begin, .ended])
+        XCTAssertEqual(received.map(\.option), [.none, .shouldResume])
+    }
+
+    func testAudioSessionRouteChangeNotificationCallsHandlerForOldDeviceUnavailable() {
+        let manager = IRAudioManager()
+        let target = NSObject()
+        var receivedReasons: [IRAudioManagerRouteChangeReason] = []
+        manager.setHandlerTarget(target, interruption: { _, _, _, _ in
+            XCTFail("Interruption handler should not be called for route change notifications")
+        }, routeChange: { handlerTarget, _, reason in
+            XCTAssertTrue(handlerTarget === target)
+            receivedReasons.append(reason)
+        })
+
+        NotificationCenter.default.post(
+            name: AVAudioSession.routeChangeNotification,
+            object: nil,
+            userInfo: [
+                AVAudioSessionRouteChangeReasonKey: AVAudioSession.RouteChangeReason.oldDeviceUnavailable.rawValue
+            ]
+        )
+        NotificationCenter.default.post(
+            name: AVAudioSession.routeChangeNotification,
+            object: nil,
+            userInfo: [
+                AVAudioSessionRouteChangeReasonKey: AVAudioSession.RouteChangeReason.newDeviceAvailable.rawValue
+            ]
+        )
+
+        XCTAssertEqual(receivedReasons, [.oldDeviceUnavailable])
+    }
+
+    func testRemoveHandlerTargetClearsMatchingOrMissingTarget() {
+        let manager = IRAudioManager()
+        let target = NSObject()
+        var interruptionCallCount = 0
+        manager.setHandlerTarget(target, interruption: { _, _, _, _ in
+            interruptionCallCount += 1
+        }, routeChange: { _, _, _ in })
+
+        manager.removeHandlerTarget(NSObject())
+        NotificationCenter.default.post(
+            name: AVAudioSession.interruptionNotification,
+            object: nil,
+            userInfo: [
+                AVAudioSessionInterruptionTypeKey: AVAudioSession.InterruptionType.began.rawValue
+            ]
+        )
+        manager.removeHandlerTarget(target)
+        NotificationCenter.default.post(
+            name: AVAudioSession.interruptionNotification,
+            object: nil,
+            userInfo: [
+                AVAudioSessionInterruptionTypeKey: AVAudioSession.InterruptionType.began.rawValue
+            ]
+        )
+        manager.removeHandlerTarget(target)
+
+        XCTAssertEqual(interruptionCallCount, 1)
+    }
+
     func testMalformedAudioSessionNotificationsAreIgnored() {
         let manager = IRAudioManager()
         let target = NSObject()


### PR DESCRIPTION
## Summary
- Add audio session interruption notification coverage for mapped interruption type and resume option handling.
- Add route-change coverage for old-device-unavailable handling and ignored non-matching route changes.
- Cover handler removal and unregistered audio manager fallback playback state.

## Verification
- xcodebuild test -project IRPlayer-swift.xcodeproj -scheme IRPlayer-swift -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:IRPlayer-swiftTests/IRAudioManagerNotificationTests -only-testing:IRPlayer-swiftTests/IRAudioManagerRenderTests
- xcodebuild test -project IRPlayer-swift.xcodeproj -scheme IRPlayer-swift -destination 'platform=iOS Simulator,name=iPhone 17' -enableCodeCoverage YES -resultBundlePath /tmp/IRPlayerCoverage.xcresult

## Coverage
- IRPlayer_swift.framework: 53.29% (6746/12660)
- IRAudioManager.swift: 21.66% (107/494)