### PR TITLE
Expand low-risk factory and video input coverage

### DIFF
--- a/IRPlayer-swift.xcodeproj/project.pbxproj
+++ b/IRPlayer-swift.xcodeproj/project.pbxproj
@@ -192,6 +192,8 @@
 		B5E950092F68A00500149265 /* IRFFFrameQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E950082F68A00500149265 /* IRFFFrameQueueTests.swift */; };
 		B5E950492F68A02200149265 /* IRFFPacketQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E950482F68A02200149265 /* IRFFPacketQueueTests.swift */; };
 		B5E950532F68A02600149265 /* IRFFVideoDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E950522F68A02600149265 /* IRFFVideoDecoderTests.swift */; };
+		B5E953132F6905000149265 /* IRFFDictionaryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E953122F6905000149265 /* IRFFDictionaryPolicyTests.swift */; };
+		B5E953152F6905100149265 /* IRFFVideoInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E953142F6905100149265 /* IRFFVideoInputTests.swift */; };
 		B5E950552F68A02700149265 /* IRPlayerLifecyclePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E950542F68A02700149265 /* IRPlayerLifecyclePolicyTests.swift */; };
 		B5E950592F68A02900149265 /* IRPlaybackTimePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E950582F68A02900149265 /* IRPlaybackTimePolicyTests.swift */; };
 		B5E9505D2F68A02B00149265 /* IRGLFisheyeTransformPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E9505C2F68A02B00149265 /* IRGLFisheyeTransformPolicyTests.swift */; };
@@ -445,6 +447,8 @@
 		B5E950082F68A00500149265 /* IRFFFrameQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRFFFrameQueueTests.swift; sourceTree = "<group>"; };
 		B5E950482F68A02200149265 /* IRFFPacketQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRFFPacketQueueTests.swift; sourceTree = "<group>"; };
 		B5E950522F68A02600149265 /* IRFFVideoDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRFFVideoDecoderTests.swift; sourceTree = "<group>"; };
+		B5E953122F6905000149265 /* IRFFDictionaryPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRFFDictionaryPolicyTests.swift; sourceTree = "<group>"; };
+		B5E953142F6905100149265 /* IRFFVideoInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRFFVideoInputTests.swift; sourceTree = "<group>"; };
 		B5E950542F68A02700149265 /* IRPlayerLifecyclePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRPlayerLifecyclePolicyTests.swift; sourceTree = "<group>"; };
 		B5E950582F68A02900149265 /* IRPlaybackTimePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRPlaybackTimePolicyTests.swift; sourceTree = "<group>"; };
 		B5E9505A2F68A02A00149265 /* IRPlaybackTimePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRPlaybackTimePolicy.swift; sourceTree = "<group>"; };
@@ -1051,6 +1055,8 @@
 				B5E950082F68A00500149265 /* IRFFFrameQueueTests.swift */,
 				B5E950482F68A02200149265 /* IRFFPacketQueueTests.swift */,
 				B5E950522F68A02600149265 /* IRFFVideoDecoderTests.swift */,
+				B5E953122F6905000149265 /* IRFFDictionaryPolicyTests.swift */,
+				B5E953142F6905100149265 /* IRFFVideoInputTests.swift */,
 				B5E9504A2F68A02300149265 /* IRFFMetadataTests.swift */,
 				B5E9504C2F68A02400149265 /* IRFFTrackTests.swift */,
 				B5E951E42F6900420149265 /* IRBounceControllerTests.swift */,
@@ -1435,6 +1441,8 @@
 				B5E950092F68A00500149265 /* IRFFFrameQueueTests.swift in Sources */,
 				B5E950492F68A02200149265 /* IRFFPacketQueueTests.swift in Sources */,
 				B5E950532F68A02600149265 /* IRFFVideoDecoderTests.swift in Sources */,
+				B5E953132F6905000149265 /* IRFFDictionaryPolicyTests.swift in Sources */,
+				B5E953152F6905100149265 /* IRFFVideoInputTests.swift in Sources */,
 				B5E9504B2F68A02300149265 /* IRFFMetadataTests.swift in Sources */,
 				B5E9504D2F68A02400149265 /* IRFFTrackTests.swift in Sources */,
 				B5E951E52F6900420149265 /* IRBounceControllerTests.swift in Sources */,

--- a/Tests/IRPlayer-swiftTests/IRFFDictionaryPolicyTests.swift
+++ b/Tests/IRPlayer-swiftTests/IRFFDictionaryPolicyTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import IRPlayer_swift
+
+final class IRFFDictionaryPolicyTests: XCTestCase {
+
+    func testFoundationDictionaryReturnsNilForMissingDictionary() {
+        XCTAssertNil(IRFFDictionaryPolicy.foundationDictionary(from: nil))
+    }
+}

--- a/Tests/IRPlayer-swiftTests/IRFFVideoInputTests.swift
+++ b/Tests/IRPlayer-swiftTests/IRFFVideoInputTests.swift
@@ -1,0 +1,47 @@
+import IRFFMpeg
+import XCTest
+@testable import IRPlayer_swift
+
+final class IRFFVideoInputTests: XCTestCase {
+
+    func testInitializerDefaultsToDisplayViewOutputWithoutVideoOutput() {
+        let input = IRFFVideoInput()
+
+        XCTAssertNil(input.videoOutput)
+        XCTAssertEqual(input.outputType, .displayView)
+    }
+
+    func testInitializerStoresVideoOutputAndOutputType() {
+        let output = RecordingFFDecoderVideoOutput()
+        let input = IRFFVideoInput(videoOutput: output, outputType: .decoder)
+
+        XCTAssertTrue(input.videoOutput === output)
+        XCTAssertEqual(input.outputType, .decoder)
+    }
+
+    func testDefaultDataSourceAlwaysHandlesPacketsAndProducesNoFrame() {
+        let input = IRFFVideoInput()
+        var packet = AVPacket()
+        packet.duration = 4
+
+        var codecContext = AVCodecContext()
+        withUnsafeMutablePointer(to: &codecContext) { codecContextPointer in
+            let info = IRFFVideoDecoderInfo(codecContext: codecContextPointer,
+                                            videoToolBoxEnable: false,
+                                            maxDecodeDuration: 2,
+                                            timebase: 0.25,
+                                            fps: 30)
+
+            XCTAssertTrue(input.shouldHandle(info, decodeFrame: packet))
+            XCTAssertNil(input.videoDecoder(info, decodeFrame: packet))
+        }
+    }
+}
+
+private final class RecordingFFDecoderVideoOutput: NSObject, IRFFDecoderVideoOutput {
+    private(set) var receivedFrames: [IRFFVideoFrame] = []
+
+    func send(videoFrame frame: IRFFVideoFrame) {
+        receivedFrames.append(frame)
+    }
+}

--- a/Tests/IRPlayer-swiftTests/IRGLProgramFactoryTests.swift
+++ b/Tests/IRPlayer-swiftTests/IRGLProgramFactoryTests.swift
@@ -207,6 +207,33 @@ final class IRGLProgramFactoryTests: XCTestCase {
         XCTAssertTrue(distortionProgram.mapProjection is IRGLProjectionVR)
     }
 
+    func testProgramFactoryWrappersReturnExpectedProgramTypes() {
+        let viewport = CGRect(x: 0, y: 0, width: 320, height: 180)
+        let parameter = makeFisheyeParameter()
+
+        XCTAssertNotNil(IRGLProgram2DFactory().createIRGLProgram(pixelFormat: .RGB_IRPixelFormat,
+                                                                 viewportRange: viewport,
+                                                                 parameter: nil))
+        XCTAssertTrue(IRGLProgram2DFisheye2PanoFactory().createIRGLProgram(pixelFormat: .RGB_IRPixelFormat,
+                                                                          viewportRange: viewport,
+                                                                          parameter: nil) is IRGLProgram2DFisheye2Pano)
+        XCTAssertTrue(IRGLProgramVRFactory().createIRGLProgram(pixelFormat: .RGB_IRPixelFormat,
+                                                              viewportRange: viewport,
+                                                              parameter: nil) is IRGLProgramVR)
+        XCTAssertTrue(IRGLProgramDistortionFactory().createIRGLProgram(pixelFormat: .RGB_IRPixelFormat,
+                                                                      viewportRange: viewport,
+                                                                      parameter: nil) is IRGLProgramDistortion)
+        XCTAssertTrue(IRGLProgram3DFisheyeFactory().createIRGLProgram(pixelFormat: .YUV_IRPixelFormat,
+                                                                     viewportRange: viewport,
+                                                                     parameter: parameter) is IRGLProgram3DFisheye)
+        XCTAssertTrue(IRGLProgram3DFisheye4PFactory().createIRGLProgram(pixelFormat: .YUV_IRPixelFormat,
+                                                                       viewportRange: viewport,
+                                                                       parameter: parameter) is IRGLProgramMulti4P)
+        XCTAssertNil(IRGLProgram3DFisheyeFactory().createIRGLProgram(pixelFormat: .YUV_IRPixelFormat,
+                                                                    viewportRange: viewport,
+                                                                    parameter: IRMediaParameter(width: 320, height: 180)))
+    }
+
     private func makeFisheyeParameter() -> IRFisheyeParameter {
         IRFisheyeParameter(width: 1440,
                            height: 1080,


### PR DESCRIPTION
## Summary
- Add IRFFVideoInput tests for initializer defaults, stored video output, and default data source behavior.
- Add nil-guard coverage for IRFFDictionaryPolicy without directly linking FFmpeg C dictionary APIs from the test bundle.
- Cover GL program factory wrapper classes for 2D, panorama, VR, distortion, fisheye, and four-panel fisheye paths.

## Verification
- xcodebuild test -project IRPlayer-swift.xcodeproj -scheme IRPlayer-swift -destination 'platform=iOS Simulator,name=iPhone 17' -jobs 1 -only-testing:IRPlayer-swiftTests/IRFFVideoInputTests -only-testing:IRPlayer-swiftTests/IRFFDictionaryPolicyTests -only-testing:IRPlayer-swiftTests/IRGLProgramFactoryTests
- xcodebuild test -project IRPlayer-swift.xcodeproj -scheme IRPlayer-swift -destination 'platform=iOS Simulator,name=iPhone 17' -jobs 1 -enableCodeCoverage YES -resultBundlePath /tmp/IRPlayerCoverage.xcresult

## Coverage
- IRPlayer_swift.framework: 53.44% (6766/12660)
- IRFFVideoInput.swift: 100.00% (11/11)
- GL program factory wrapper files: 100.00%