### PR TITLE
Expand GL program model coverage

### DIFF
--- a/IRPlayer-swift.xcodeproj/project.pbxproj
+++ b/IRPlayer-swift.xcodeproj/project.pbxproj
@@ -235,10 +235,12 @@
 		B5E951B72F6900130149265 /* IRMetalRendererDistortionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E951B62F6900130149265 /* IRMetalRendererDistortionTests.swift */; };
 		B5E950352F68A01800149265 /* IRePTZShiftControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E950342F68A01800149265 /* IRePTZShiftControllerTests.swift */; };
 		B5E950372F68A01900149265 /* IRGLProgram2DTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E950362F68A01900149265 /* IRGLProgram2DTests.swift */; };
+		B5E953172F6905200149265 /* IRGLProgram3DFisheyeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E953162F6905200149265 /* IRGLProgram3DFisheyeTests.swift */; };
 		B5E950392F68A01A00149265 /* IRGLTransformController2DTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E950382F68A01A00149265 /* IRGLTransformController2DTests.swift */; };
 		B5E9503B2F68A01B00149265 /* IRGLTransformController3DFisheyeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E9503A2F68A01B00149265 /* IRGLTransformController3DFisheyeTests.swift */; };
 			B5E9503D2F68A01C00149265 /* IRGLTransformControllerVRTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E9503C2F68A01C00149265 /* IRGLTransformControllerVRTests.swift */; };
 			B5E9503F2F68A01D00149265 /* IRGLProgramFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E9503E2F68A01D00149265 /* IRGLProgramFactoryTests.swift */; };
+			B5E953192F6905300149265 /* IRGLProgramVRTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E953182F6905300149265 /* IRGLProgramVRTests.swift */; };
 			B5E951F12F6900500149265 /* IRGLProjectionEquirectangularTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E951F02F6900500149265 /* IRGLProjectionEquirectangularTests.swift */; };
 			B5E951F32F6900510149265 /* IRGLProjectionVRTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E951F22F6900510149265 /* IRGLProjectionVRTests.swift */; };
 			B5E950412F68A01E00149265 /* IRGLProgramMulti4PTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E950402F68A01E00149265 /* IRGLProgramMulti4PTests.swift */; };
@@ -491,10 +493,12 @@
 		B5E951B62F6900130149265 /* IRMetalRendererDistortionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRMetalRendererDistortionTests.swift; sourceTree = "<group>"; };
 		B5E950342F68A01800149265 /* IRePTZShiftControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRePTZShiftControllerTests.swift; sourceTree = "<group>"; };
 		B5E950362F68A01900149265 /* IRGLProgram2DTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRGLProgram2DTests.swift; sourceTree = "<group>"; };
+		B5E953162F6905200149265 /* IRGLProgram3DFisheyeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRGLProgram3DFisheyeTests.swift; sourceTree = "<group>"; };
 		B5E950382F68A01A00149265 /* IRGLTransformController2DTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRGLTransformController2DTests.swift; sourceTree = "<group>"; };
 		B5E9503A2F68A01B00149265 /* IRGLTransformController3DFisheyeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRGLTransformController3DFisheyeTests.swift; sourceTree = "<group>"; };
 			B5E9503C2F68A01C00149265 /* IRGLTransformControllerVRTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRGLTransformControllerVRTests.swift; sourceTree = "<group>"; };
 			B5E9503E2F68A01D00149265 /* IRGLProgramFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRGLProgramFactoryTests.swift; sourceTree = "<group>"; };
+			B5E953182F6905300149265 /* IRGLProgramVRTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRGLProgramVRTests.swift; sourceTree = "<group>"; };
 			B5E951F02F6900500149265 /* IRGLProjectionEquirectangularTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRGLProjectionEquirectangularTests.swift; sourceTree = "<group>"; };
 			B5E951F22F6900510149265 /* IRGLProjectionVRTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRGLProjectionVRTests.swift; sourceTree = "<group>"; };
 			B5E950402F68A01E00149265 /* IRGLProgramMulti4PTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRGLProgramMulti4PTests.swift; sourceTree = "<group>"; };
@@ -1067,8 +1071,10 @@
 					B5E950242F68A01300149265 /* IRGLProgram2DFisheye2PanoTests.swift */,
 					B5E950302F68A01600149265 /* IRGLProgram2DFisheye2PerspTests.swift */,
 					B5E950362F68A01900149265 /* IRGLProgram2DTests.swift */,
+					B5E953162F6905200149265 /* IRGLProgram3DFisheyeTests.swift */,
 					B5E950502F68A02500149265 /* IRGLProgramDistortionTests.swift */,
 					B5E9503E2F68A01D00149265 /* IRGLProgramFactoryTests.swift */,
+					B5E953182F6905300149265 /* IRGLProgramVRTests.swift */,
 					B5E951F02F6900500149265 /* IRGLProjectionEquirectangularTests.swift */,
 					B5E951F22F6900510149265 /* IRGLProjectionVRTests.swift */,
 					B5E950402F68A01E00149265 /* IRGLProgramMulti4PTests.swift */,
@@ -1452,8 +1458,10 @@
 					B5E950252F68A01300149265 /* IRGLProgram2DFisheye2PanoTests.swift in Sources */,
 					B5E950312F68A01600149265 /* IRGLProgram2DFisheye2PerspTests.swift in Sources */,
 					B5E950372F68A01900149265 /* IRGLProgram2DTests.swift in Sources */,
+					B5E953172F6905200149265 /* IRGLProgram3DFisheyeTests.swift in Sources */,
 					B5E950512F68A02500149265 /* IRGLProgramDistortionTests.swift in Sources */,
 					B5E9503F2F68A01D00149265 /* IRGLProgramFactoryTests.swift in Sources */,
+					B5E953192F6905300149265 /* IRGLProgramVRTests.swift in Sources */,
 					B5E951F12F6900500149265 /* IRGLProjectionEquirectangularTests.swift in Sources */,
 					B5E951F32F6900510149265 /* IRGLProjectionVRTests.swift in Sources */,
 					B5E950412F68A01E00149265 /* IRGLProgramMulti4PTests.swift in Sources */,

--- a/Tests/IRPlayer-swiftTests/IRGLProgram3DFisheyeTests.swift
+++ b/Tests/IRPlayer-swiftTests/IRGLProgram3DFisheyeTests.swift
@@ -1,0 +1,61 @@
+import CoreGraphics
+import XCTest
+@testable import IRPlayer_swift
+
+final class IRGLProgram3DFisheyeTests: XCTestCase {
+
+    func testOutputSizeUpdateRefreshesAutoUpdatingParameterAndProjection() {
+        let parameter = IRMediaParameter(width: 320, height: 180)
+        let projection = RecordingProjection()
+        let program = IRGLProgram3DFisheye(pixelFormat: .RGB_IRPixelFormat,
+                                          viewportRange: CGRect(x: 0, y: 0, width: 320, height: 180),
+                                          parameter: parameter)
+        program.mapProjection = projection
+
+        program.didUpdateOutputWH(640, 360)
+
+        XCTAssertEqual(parameter.width, 640)
+        XCTAssertEqual(parameter.height, 360)
+        XCTAssertTrue(projection.updatedParameter === parameter)
+    }
+
+    func testOutputSizeUpdateIgnoresDisabledAutoUpdateOrUnchangedSize() {
+        let parameter = IRMediaParameter(width: 320, height: 180)
+        let projection = RecordingProjection()
+        let program = IRGLProgram3DFisheye(pixelFormat: .RGB_IRPixelFormat,
+                                          viewportRange: .zero,
+                                          parameter: parameter)
+        program.mapProjection = projection
+
+        program.didUpdateOutputWH(320, 180)
+        XCTAssertNil(projection.updatedParameter)
+
+        parameter.autoUpdate = false
+        program.didUpdateOutputWH(640, 360)
+
+        XCTAssertEqual(parameter.width, 320)
+        XCTAssertEqual(parameter.height, 180)
+        XCTAssertNil(projection.updatedParameter)
+    }
+
+    func testVerticalScrollRejectsVerticalBoundsOnly() {
+        let program = IRGLProgram3DFisheye()
+        let controller = IRGLTransformController()
+
+        XCTAssertFalse(program.doScrollVertical(status: [.toMaxY], transformController: controller))
+        XCTAssertFalse(program.doScrollVertical(status: [.toMinY], transformController: controller))
+        XCTAssertTrue(program.doScrollVertical(status: [.toMaxX], transformController: controller))
+        XCTAssertTrue(program.doScrollVertical(status: [], transformController: controller))
+    }
+}
+
+private final class RecordingProjection: IRGLProjection {
+    private(set) var updatedParameter: IRMediaParameter?
+
+    func update(with parameter: IRMediaParameter) {
+        updatedParameter = parameter
+    }
+
+    func updateVertex() {}
+    func draw() {}
+}

--- a/Tests/IRPlayer-swiftTests/IRGLProgramVRTests.swift
+++ b/Tests/IRPlayer-swiftTests/IRGLProgramVRTests.swift
@@ -1,0 +1,68 @@
+import CoreGraphics
+import XCTest
+@testable import IRPlayer_swift
+
+final class IRGLProgramVRTests: XCTestCase {
+
+    func testDoubleTapRestoresInitialDefaultScaleForFisheyeController() {
+        let controller = RecordingFisheyeTransformController(viewportWidth: 320,
+                                                             viewportHeight: 180,
+                                                             tileType: .up)
+        let program = IRGLProgramVR(pixelFormat: .RGB_IRPixelFormat,
+                                    viewportRange: CGRect(x: 0, y: 0, width: 320, height: 180),
+                                    parameter: nil)
+        program.tramsformController = controller
+
+        program.setDefaultScale(2)
+        program.setDefaultScale(3)
+        controller.recordedUpdates.removeAll()
+        program.didDoubleTap()
+
+        XCTAssertEqual(controller.recordedUpdates, [
+            .init(fx: 0, fy: 0, sx: 2, sy: 2)
+        ])
+    }
+
+    func testDoubleTapFallsBackToDefaultUpdateWithoutInitialScale() {
+        let controller = RecordingDefaultTransformController()
+        let program = IRGLProgramVR()
+        program.tramsformController = controller
+
+        program.didDoubleTap()
+
+        XCTAssertEqual(controller.updateToDefaultCallCount, 1)
+    }
+
+    func testVerticalScrollRejectsVerticalBoundsOnly() {
+        let program = IRGLProgramVR()
+        let controller = IRGLTransformController()
+
+        XCTAssertFalse(program.doScrollVertical(status: [.toMaxY], transformController: controller))
+        XCTAssertFalse(program.doScrollVertical(status: [.toMinY], transformController: controller))
+        XCTAssertTrue(program.doScrollVertical(status: [.toMaxX], transformController: controller))
+        XCTAssertTrue(program.doScrollVertical(status: [], transformController: controller))
+    }
+}
+
+private final class RecordingFisheyeTransformController: IRGLTransformController3DFisheye {
+    struct Update: Equatable {
+        let fx: Float
+        let fy: Float
+        let sx: Float
+        let sy: Float
+    }
+
+    var recordedUpdates: [Update] = []
+
+    override func update(fx: Float, fy: Float, sx: Float, sy: Float) {
+        recordedUpdates.append(Update(fx: fx, fy: fy, sx: sx, sy: sy))
+    }
+}
+
+private final class RecordingDefaultTransformController: IRGLTransformController {
+    private(set) var updateToDefaultCallCount = 0
+
+    override func updateToDefault() {
+        updateToDefaultCallCount += 1
+    }
+}


### PR DESCRIPTION
## Summary
- Add IRGLProgram3DFisheye tests for auto-updating output dimensions, projection updates, and vertical scroll bounds handling.
- Add IRGLProgramVR tests for double-tap scale restoration, default fallback behavior, and vertical scroll bounds handling.
- Register the new program-level tests in the Xcode test target.

## Verification
- xcodebuild test -project IRPlayer-swift.xcodeproj -scheme IRPlayer-swift -destination 'platform=iOS Simulator,name=iPhone 17' -jobs 1 -only-testing:IRPlayer-swiftTests/IRGLProgram3DFisheyeTests -only-testing:IRPlayer-swiftTests/IRGLProgramVRTests
- xcodebuild test -project IRPlayer-swift.xcodeproj -scheme IRPlayer-swift -destination 'platform=iOS Simulator,name=iPhone 17' -jobs 1 -enableCodeCoverage YES -resultBundlePath /tmp/IRPlayerCoverage.xcresult

## Coverage
- IRPlayer_swift.framework: 53.84% (6816/12660)
- IRGLProgram3DFisheye.swift: 100.00% (19/19)
- IRGLProgramVR.swift: 100.00% (21/21)