### PR TITLE
Expand multi program coverage

### DIFF
--- a/IRPlayer-swift.xcodeproj/project.pbxproj
+++ b/IRPlayer-swift.xcodeproj/project.pbxproj
@@ -243,6 +243,7 @@
 			B5E953192F6905300149265 /* IRGLProgramVRTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E953182F6905300149265 /* IRGLProgramVRTests.swift */; };
 			B5E951F12F6900500149265 /* IRGLProjectionEquirectangularTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E951F02F6900500149265 /* IRGLProjectionEquirectangularTests.swift */; };
 			B5E951F32F6900510149265 /* IRGLProjectionVRTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E951F22F6900510149265 /* IRGLProjectionVRTests.swift */; };
+			B5E9531B2F6910100149265 /* IRGLProgramMultiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E9531A2F6910100149265 /* IRGLProgramMultiTests.swift */; };
 			B5E950412F68A01E00149265 /* IRGLProgramMulti4PTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E950402F68A01E00149265 /* IRGLProgramMulti4PTests.swift */; };
 			B5E950432F68A01F00149265 /* IRGLScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E950422F68A01F00149265 /* IRGLScopeTests.swift */; };
 			B5E950452F68A02000149265 /* IRGLRenderModeBuildTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E950442F68A02000149265 /* IRGLRenderModeBuildTests.swift */; };
@@ -501,6 +502,7 @@
 			B5E953182F6905300149265 /* IRGLProgramVRTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRGLProgramVRTests.swift; sourceTree = "<group>"; };
 			B5E951F02F6900500149265 /* IRGLProjectionEquirectangularTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRGLProjectionEquirectangularTests.swift; sourceTree = "<group>"; };
 			B5E951F22F6900510149265 /* IRGLProjectionVRTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRGLProjectionVRTests.swift; sourceTree = "<group>"; };
+			B5E9531A2F6910100149265 /* IRGLProgramMultiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRGLProgramMultiTests.swift; sourceTree = "<group>"; };
 			B5E950402F68A01E00149265 /* IRGLProgramMulti4PTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRGLProgramMulti4PTests.swift; sourceTree = "<group>"; };
 			B5E950422F68A01F00149265 /* IRGLScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRGLScopeTests.swift; sourceTree = "<group>"; };
 			B5E950442F68A02000149265 /* IRGLRenderModeBuildTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IRGLRenderModeBuildTests.swift; sourceTree = "<group>"; };
@@ -1077,6 +1079,7 @@
 					B5E953182F6905300149265 /* IRGLProgramVRTests.swift */,
 					B5E951F02F6900500149265 /* IRGLProjectionEquirectangularTests.swift */,
 					B5E951F22F6900510149265 /* IRGLProjectionVRTests.swift */,
+					B5E9531A2F6910100149265 /* IRGLProgramMultiTests.swift */,
 					B5E950402F68A01E00149265 /* IRGLProgramMulti4PTests.swift */,
 				B5E950442F68A02000149265 /* IRGLRenderModeBuildTests.swift */,
 				B5E9500A2F68A00600149265 /* IRGLRenderModeFactoryTests.swift */,
@@ -1464,6 +1467,7 @@
 					B5E953192F6905300149265 /* IRGLProgramVRTests.swift in Sources */,
 					B5E951F12F6900500149265 /* IRGLProjectionEquirectangularTests.swift in Sources */,
 					B5E951F32F6900510149265 /* IRGLProjectionVRTests.swift in Sources */,
+					B5E9531B2F6910100149265 /* IRGLProgramMultiTests.swift in Sources */,
 					B5E950412F68A01E00149265 /* IRGLProgramMulti4PTests.swift in Sources */,
 				B5E950452F68A02000149265 /* IRGLRenderModeBuildTests.swift in Sources */,
 				B5E9500B2F68A00600149265 /* IRGLRenderModeFactoryTests.swift in Sources */,

--- a/Tests/IRPlayer-swiftTests/IRGLProgramMultiTests.swift
+++ b/Tests/IRPlayer-swiftTests/IRGLProgramMultiTests.swift
@@ -1,0 +1,185 @@
+import CoreGraphics
+import XCTest
+@testable import IRPlayer_swift
+
+final class IRGLProgramMultiTests: XCTestCase {
+
+    func testContentModeViewportTextureAndFrameAreForwardedToChildren() {
+        let children = [RecordingProgram2D(), RecordingProgram2D()]
+        let program = IRGLProgramMulti(programs: children,
+                                       viewprotRange: CGRect(x: 0, y: 0, width: 100, height: 50))
+        let frame = IRFFVideoFrame()
+        frame.width = 640
+        frame.height = 360
+
+        program.contentMode = .scaleAspectFill
+        program.setViewportRange(CGRect(x: 10, y: 20, width: 300, height: 150), resetTransform: false)
+        program.updateTextureWidth(640, height: 360)
+        program.setRenderFrame(frame)
+
+        XCTAssertEqual(children.map(\.contentMode), [.scaleAspectFill, .scaleAspectFill])
+        XCTAssertEqual(children.map(\.viewportCalls.last), [
+            .init(range: CGRect(x: 10, y: 20, width: 300, height: 150), resetTransform: false),
+            .init(range: CGRect(x: 10, y: 20, width: 300, height: 150), resetTransform: false)
+        ])
+        XCTAssertEqual(children.map(\.textureUpdates.last), [
+            .init(width: 640, height: 360),
+            .init(width: 640, height: 360)
+        ])
+        XCTAssertTrue(children.allSatisfy { $0.renderedFrames.last === frame })
+    }
+
+    func testTouchAggregatesChildrenAndOutputSizeIsZero() {
+        let miss = RecordingProgram2D(touchResult: false)
+        let hit = RecordingProgram2D(touchResult: true)
+        let program = IRGLProgramMulti(programs: [miss, hit],
+                                       viewprotRange: CGRect(x: 0, y: 0, width: 100, height: 50))
+
+        XCTAssertTrue(program.touchedInProgram(CGPoint(x: 500, y: 500)))
+        XCTAssertEqual(miss.touchedPoints, [CGPoint(x: 500, y: 500)])
+        XCTAssertEqual(hit.touchedPoints, [CGPoint(x: 500, y: 500)])
+        XCTAssertEqual(program.getOutputSize(), .zero)
+    }
+
+    func testScalePanPinchAndDoubleTapAreForwardedToChildren() {
+        let children = [RecordingProgram2D(), RecordingProgram2D()]
+        let controllers = [
+            RecordingTransformController(scopeScaleX: 2, scopeScaleY: 3),
+            RecordingTransformController(scopeScaleX: 4, scopeScaleY: 5)
+        ]
+        for (child, controller) in zip(children, controllers) {
+            child.tramsformController = controller
+        }
+        let program = IRGLProgramMulti(programs: children,
+                                       viewprotRange: CGRect(x: 0, y: 0, width: 100, height: 50))
+
+        program.setDefaultScale(1.5)
+        program.didPanBydx(12, dy: -8)
+        program.didPanByDegreeX(90, degreeY: -45)
+        program.didPinchByfx(10, fy: 20, dsx: 1.5, dsy: 2)
+        program.didPinchByfx(30, fy: 40, sx: 6, sy: 7)
+        program.didDoubleTap()
+
+        XCTAssertEqual(children.map(\.defaultScales), [[1.5], [1.5]])
+        XCTAssertEqual(controllers.map(\.scrollDeltaCalls), [
+            [.init(dx: 12, dy: -8)],
+            [.init(dx: 12, dy: -8)]
+        ])
+        XCTAssertEqual(controllers.map(\.scrollDegreeCalls), [
+            [.init(degreeX: 90, degreeY: -45)],
+            [.init(degreeX: 90, degreeY: -45)]
+        ])
+        XCTAssertEqual(children.map(\.pinchCalls), [
+            [
+                .init(fx: 10, fy: 20, sx: 3, sy: 6),
+                .init(fx: 30, fy: 40, sx: 6, sy: 7)
+            ],
+            [
+                .init(fx: 10, fy: 20, sx: 6, sy: 10),
+                .init(fx: 30, fy: 40, sx: 6, sy: 7)
+            ]
+        ])
+        XCTAssertEqual(children.map(\.doubleTapCallCount), [1, 1])
+    }
+}
+
+private final class RecordingProgram2D: IRGLProgram2D {
+    struct ViewportCall: Equatable {
+        let range: CGRect
+        let resetTransform: Bool
+    }
+
+    struct TextureUpdate: Equatable {
+        let width: Int
+        let height: Int
+    }
+
+    struct PinchCall: Equatable {
+        let fx: Float
+        let fy: Float
+        let sx: Float
+        let sy: Float
+    }
+
+    private let touchResult: Bool
+    private(set) var viewportCalls: [ViewportCall] = []
+    private(set) var textureUpdates: [TextureUpdate] = []
+    private(set) var renderedFrames: [IRFFVideoFrame] = []
+    private(set) var defaultScales: [Float] = []
+    private(set) var touchedPoints: [CGPoint] = []
+    private(set) var pinchCalls: [PinchCall] = []
+    private(set) var doubleTapCallCount = 0
+
+    init(touchResult: Bool = false) {
+        self.touchResult = touchResult
+        super.init(pixelFormat: .RGB_IRPixelFormat, viewportRange: .zero, parameter: nil)
+    }
+
+    override func setViewportRange(_ viewportRange: CGRect, resetTransform: Bool = true) {
+        viewportCalls.append(ViewportCall(range: viewportRange, resetTransform: resetTransform))
+    }
+
+    override func updateTextureWidth(_ w: Int, height h: Int) {
+        textureUpdates.append(TextureUpdate(width: w, height: h))
+    }
+
+    override func setRenderFrame(_ frame: IRFFVideoFrame) {
+        renderedFrames.append(frame)
+    }
+
+    override func setDefaultScale(_ scale: Float) {
+        defaultScales.append(scale)
+    }
+
+    override func touchedInProgram(_ touchedPoint: CGPoint) -> Bool {
+        touchedPoints.append(touchedPoint)
+        return touchResult
+    }
+
+    override func didPinchByfx(_ fx: Float, fy: Float, sx: Float, sy: Float) {
+        pinchCalls.append(PinchCall(fx: fx, fy: fy, sx: sx, sy: sy))
+    }
+
+    override func didDoubleTap() {
+        doubleTapCallCount += 1
+    }
+}
+
+private final class RecordingTransformController: IRGLTransformController {
+    struct ScrollDelta: Equatable {
+        let dx: Float
+        let dy: Float
+    }
+
+    struct ScrollDegree: Equatable {
+        let degreeX: Float
+        let degreeY: Float
+    }
+
+    private let scope: IRGLScope2D
+    private(set) var scrollDeltaCalls: [ScrollDelta] = []
+    private(set) var scrollDegreeCalls: [ScrollDegree] = []
+
+    init(scopeScaleX: Float, scopeScaleY: Float) {
+        scope = IRGLScope2D(scaleX: scopeScaleX,
+                            scaleY: scopeScaleY,
+                            offsetX: 0,
+                            offsetY: 0,
+                            panDegree: 0,
+                            w: 0,
+                            h: 0)
+        super.init()
+    }
+
+    override func getScope() -> IRGLScope2D {
+        scope
+    }
+
+    override func scroll(dx: Float, dy: Float) {
+        scrollDeltaCalls.append(ScrollDelta(dx: dx, dy: dy))
+    }
+
+    override func scroll(degreeX: Float, degreeY: Float) {
+        scrollDegreeCalls.append(ScrollDegree(degreeX: degreeX, degreeY: degreeY))
+    }
+}


### PR DESCRIPTION
## Summary
- Add IRGLProgramMulti forwarding regression tests for child content mode, viewport, texture size, render frame, touch aggregation, transform scrolling, pinch scaling, and double tap forwarding
- Add the new test file to the Xcode test target

## Verification
- xcodebuild test -project IRPlayer-swift.xcodeproj -scheme IRPlayer-swift -destination 'platform=iOS Simulator,name=iPhone 17' -jobs 1 -only-testing:IRPlayer-swiftTests/IRGLProgramMultiTests
- xcodebuild test -project IRPlayer-swift.xcodeproj -scheme IRPlayer-swift -destination 'platform=iOS Simulator,name=iPhone 17' -jobs 1 -enableCodeCoverage YES -resultBundlePath /tmp/IRPlayerCoverage.xcresult

## Coverage
- IRPlayer_swift.framework: 54.34% (6880/12660)
- IRGLProgramMulti.swift: 97.33% (73/75)
- Test suite: 552 tests, 2 skipped, 0 failures