### PR TITLE
Cover platform image creation

### DIFF
--- a/Tests/IRPlayer-swiftTests/IRPLFImageTests.swift
+++ b/Tests/IRPlayer-swiftTests/IRPLFImageTests.swift
@@ -10,6 +10,38 @@ import XCTest
 
 final class IRPLFImageTests: XCTestCase {
 
+    func testCGImageWithRGBDataBuildsImageWithExpectedGeometry() {
+        let pixels: [UInt8] = [
+            255, 0, 0, 0, 255, 0,
+            0, 0, 255, 255, 255, 255
+        ]
+
+        let image = pixels.withUnsafeBufferPointer { buffer in
+            IRPLFImageCGImageWithRGBData(buffer.baseAddress!, linesize: 6, width: 2, height: 2)
+        }
+
+        XCTAssertEqual(image?.width, 2)
+        XCTAssertEqual(image?.height, 2)
+        XCTAssertEqual(image?.bitsPerComponent, 8)
+        XCTAssertEqual(image?.bitsPerPixel, 24)
+        XCTAssertEqual(image?.bytesPerRow, 6)
+    }
+
+    func testImageWithRGBDataWrapsCGImage() {
+        let pixels: [UInt8] = [
+            10, 20, 30,
+            40, 50, 60
+        ]
+
+        let image = pixels.withUnsafeBufferPointer { buffer in
+            IRPLFImageWithRGBData(buffer.baseAddress!, linesize: 3, width: 1, height: 2)
+        }
+
+        XCTAssertEqual(image?.size.width, 1)
+        XCTAssertEqual(image?.size.height, 2)
+        XCTAssertNotNil(image?.cgImage)
+    }
+
     func testRGBDataByteCountRejectsInvalidOrOverflowingInputs() {
         XCTAssertNil(IRPLFImageRGBDataByteCount(linesize: 0, width: 4, height: 4))
         XCTAssertNil(IRPLFImageRGBDataByteCount(linesize: 12, width: 0, height: 4))


### PR DESCRIPTION
## Summary
- Add success-path coverage for RGB buffer to CGImage creation
- Verify the UIImage wrapper preserves expected image geometry and carries a CGImage

## Verification
- xcodebuild test -project IRPlayer-swift.xcodeproj -scheme IRPlayer-swift -destination 'platform=iOS Simulator,name=iPhone 17' -jobs 1 -only-testing:IRPlayer-swiftTests/IRPLFImageTests
- xcodebuild test -project IRPlayer-swift.xcodeproj -scheme IRPlayer-swift -destination 'platform=iOS Simulator,name=iPhone 17' -jobs 1 -enableCodeCoverage YES -resultBundlePath /tmp/IRPlayerCoverage.xcresult

## Coverage
- IRPlayer_swift.framework: 54.69% (6924/12660)
- IRPLFImage.swift: 90.48% (38/42)
- Test suite: 556 tests, 2 skipped, 0 failures