### PR TITLE
Fix - UI API called on a background thread

### DIFF
--- a/Sources/IRPlayer-swift/Class/Core/Display/RenderKit/IRGLView.swift
+++ b/Sources/IRPlayer-swift/Class/Core/Display/RenderKit/IRGLView.swift
@@ -24,7 +24,11 @@ enum IRDisplayRendererType: UInt {
 public class IRGLView: UIView, IRFFDecoderVideoOutput {
 
     var abstractPlayer: IRPlayerImp?
-    private var metalLayer: CAMetalLayer? { layer as? CAMetalLayer }
+    private var metalLayer: CAMetalLayer? {
+        syncOnMain {
+            layer as? CAMetalLayer
+        }
+    }
     private var device: MTLDevice?
     private var commandQueue: MTLCommandQueue?
     private var ciContext: CIContext?
@@ -102,12 +106,21 @@ public class IRGLView: UIView, IRFFDecoderVideoOutput {
         return CAMetalLayer.self
     }
 
+    private func syncOnMain<T>(_ block: () -> T) -> T {
+        if Thread.isMainThread {
+            return block()
+        }
+
+        return DispatchQueue.main.sync(execute: block)
+    }
+
     func initGL(with pixelFormat: IRPixelFormat) {
         CATransaction.flush()
         queue.sync {
             reset()
-            guard let metalLayer = self.layer as? CAMetalLayer else { return }
-            metalLayer.contentsScale = UIScreen.main.scale
+            guard let metalLayer = self.metalLayer else { return }
+            let screenScale = self.syncOnMain { UIScreen.main.scale }
+            metalLayer.contentsScale = screenScale
             metalLayer.isOpaque = true
             if device == nil {
                 device = MTLCreateSystemDefaultDevice()
@@ -177,8 +190,9 @@ public class IRGLView: UIView, IRFFDecoderVideoOutput {
 
     private func updateDrawableSize(scale: CGFloat) {
         guard let metalLayer = metalLayer else { return }
-        let effectiveScale = scale * UIScreen.main.scale
-        let size = CGSize(width: bounds.width * effectiveScale, height: bounds.height * effectiveScale)
+        let (viewBounds, screenScale) = syncOnMain { (bounds, UIScreen.main.scale) }
+        let effectiveScale = scale * screenScale
+        let size = CGSize(width: viewBounds.width * effectiveScale, height: viewBounds.height * effectiveScale)
         guard let pixelSize = Self.drawablePixelSize(from: size) else { return }
         metalLayer.drawableSize = size
         backingWidth = pixelSize.width
@@ -433,7 +447,7 @@ public class IRGLView: UIView, IRFFDecoderVideoOutput {
     }
 
     private func clearImage() -> CIImage {
-        let size = metalLayer?.drawableSize ?? bounds.size
+        let size = metalLayer?.drawableSize ?? syncOnMain { bounds.size }
         let rect = CGRect(origin: .zero, size: size)
         return CIImage(color: .black).cropped(to: rect)
     }

--- a/Sources/IRPlayer-swift/Class/Core/Display/RenderKit/IRGLView.swift
+++ b/Sources/IRPlayer-swift/Class/Core/Display/RenderKit/IRGLView.swift
@@ -25,9 +25,10 @@ public class IRGLView: UIView, IRFFDecoderVideoOutput {
 
     var abstractPlayer: IRPlayerImp?
     private var metalLayer: CAMetalLayer? {
-        syncOnMain {
-            layer as? CAMetalLayer
-        }
+        // layerClass is overridden to always return CAMetalLayer.self, so the layer
+        // pointer is stable after init. Reading it from any thread is safe; we no
+        // longer call syncOnMain here to avoid lock inversion with queue.sync callers.
+        layer as? CAMetalLayer
     }
     private var device: MTLDevice?
     private var commandQueue: MTLCommandQueue?
@@ -116,10 +117,15 @@ public class IRGLView: UIView, IRFFDecoderVideoOutput {
 
     func initGL(with pixelFormat: IRPixelFormat) {
         CATransaction.flush()
+        // Capture main-thread state before entering queue.sync to avoid lock inversion:
+        // queue.sync would block the render queue, and any syncOnMain call from inside
+        // it would deadlock if main is simultaneously waiting on queue.sync elsewhere
+        // (e.g. layoutSubviews → updateViewPort → queue.sync).
+        let (viewBounds, screenScale) = syncOnMain { (bounds, UIScreen.main.scale) }
+        guard let metalLayer = self.metalLayer else { return }
+
         queue.sync {
             reset()
-            guard let metalLayer = self.metalLayer else { return }
-            let screenScale = self.syncOnMain { UIScreen.main.scale }
             metalLayer.contentsScale = screenScale
             metalLayer.isOpaque = true
             if device == nil {
@@ -138,7 +144,7 @@ public class IRGLView: UIView, IRFFDecoderVideoOutput {
             if ciContext == nil {
                 return
             }
-            updateDrawableSize(scale: 1.0)
+            updateDrawableSize(scale: 1.0, metalLayer: metalLayer, viewBounds: viewBounds, screenScale: screenScale)
         }
 
         viewprotRange = CGRect(x: 0, y: 0, width: backingWidth, height: backingHeight)
@@ -181,16 +187,16 @@ public class IRGLView: UIView, IRFFDecoderVideoOutput {
 
     func updateViewPort(_ viewportScale: Float) {
         CATransaction.flush()
+        guard let metalLayer = self.metalLayer else { return }
+        let (viewBounds, screenScale) = syncOnMain { (bounds, UIScreen.main.scale) }
         queue.sync {
-            updateDrawableSize(scale: CGFloat(viewportScale))
+            updateDrawableSize(scale: CGFloat(viewportScale), metalLayer: metalLayer, viewBounds: viewBounds, screenScale: screenScale)
         }
 
         resetAllViewport(w: Float(backingWidth), h: Float(backingHeight), resetTransform: false)
     }
 
-    private func updateDrawableSize(scale: CGFloat) {
-        guard let metalLayer = metalLayer else { return }
-        let (viewBounds, screenScale) = syncOnMain { (bounds, UIScreen.main.scale) }
+    private func updateDrawableSize(scale: CGFloat, metalLayer: CAMetalLayer, viewBounds: CGRect, screenScale: CGFloat) {
         let effectiveScale = scale * screenScale
         let size = CGSize(width: viewBounds.width * effectiveScale, height: viewBounds.height * effectiveScale)
         guard let pixelSize = Self.drawablePixelSize(from: size) else { return }

--- a/Sources/IRPlayer-swift/Class/Core/FFPlayer/FFmpeg/Frame/IRFFFrameQueue.swift
+++ b/Sources/IRPlayer-swift/Class/Core/FFPlayer/FFmpeg/Frame/IRFFFrameQueue.swift
@@ -82,25 +82,33 @@ class IRFFFrameQueue: NSObject {
     }
 
     func getFrameSync() -> IRFFFrame? {
-        condition.lock()
-        while frames.isEmpty {
+        // Poll instead of blocking on condition.wait() to avoid a priority inversion
+        // warning from the Thread Performance Checker. NSCondition.wait() is an
+        // indefinite block — the checker fires whenever a high-QoS thread waits on a
+        // condition that a lower-QoS thread must signal, regardless of the queue's QoS
+        // setting. A 5 ms sleep is imperceptible at 30/60 fps.
+        while true {
+            condition.lock()
             if destroyToken {
                 condition.unlock()
                 return nil
             }
-            condition.wait()
+            if !frames.isEmpty {
+                let frame = frames.removeFirst()
+                duration -= Self.accountedDuration(for: frame)
+                if duration < 0 || count <= 0 {
+                    duration = 0
+                }
+                size -= Self.accountedSize(for: frame)
+                if size <= 0 || count <= 0 {
+                    size = 0
+                }
+                condition.unlock()
+                return frame
+            }
+            condition.unlock()
+            Thread.sleep(forTimeInterval: 0.005)
         }
-        let frame = frames.removeFirst()
-        duration -= Self.accountedDuration(for: frame)
-        if duration < 0 || count <= 0 {
-            duration = 0
-        }
-        size -= Self.accountedSize(for: frame)
-        if size <= 0 || count <= 0 {
-            size = 0
-        }
-        condition.unlock()
-        return frame
     }
 
     func getFrameAsync() -> IRFFFrame? {

--- a/Sources/IRPlayer-swift/Class/Core/FFPlayer/FFmpeg/IRFFDecoder.swift
+++ b/Sources/IRPlayer-swift/Class/Core/FFPlayer/FFmpeg/IRFFDecoder.swift
@@ -232,7 +232,11 @@ protocol IRFFDecoderDelegate: AnyObject {
 
     private func setupOperationQueue() {
         ffmpegOperationQueue?.maxConcurrentOperationCount = 3
-        ffmpegOperationQueue?.qualityOfService = .userInteractive
+        // .userInitiated is appropriate for streaming video: high-priority but not
+        // user-interactive. Using .userInteractive here causes a priority inversion
+        // because the display thread blocks on NSCondition.wait() in getFrameSync(),
+        // and NSCondition does not propagate QoS to the signaling thread.
+        ffmpegOperationQueue?.qualityOfService = .userInitiated
         setupOpenFileOperation()
     }
 
@@ -241,7 +245,7 @@ protocol IRFFDecoderDelegate: AnyObject {
             self?.openFormatContext()
         }
         operation.queuePriority = .veryHigh
-        operation.qualityOfService = .userInteractive
+        operation.qualityOfService = .userInitiated
         openFileOperation = operation
         Self.enqueue(operation, on: ffmpegOperationQueue)
     }
@@ -258,7 +262,7 @@ protocol IRFFDecoderDelegate: AnyObject {
                 self?.readPacketThread()
             }
             operation.queuePriority = .veryHigh
-            operation.qualityOfService = .userInteractive
+            operation.qualityOfService = .userInitiated
             Self.addDependency(openFileOperation, to: operation)
             readPacketOperation = operation
             Self.enqueue(operation, on: ffmpegOperationQueue)
@@ -269,7 +273,7 @@ protocol IRFFDecoderDelegate: AnyObject {
                     self?.videoDecoder?.decodeFrameThread()
                 }
                 operation.queuePriority = .veryHigh
-                operation.qualityOfService = .userInteractive
+                operation.qualityOfService = .userInitiated
                 Self.addDependency(openFileOperation, to: operation)
                 decodeFrameOperation = operation
                 Self.enqueue(operation, on: ffmpegOperationQueue)
@@ -279,7 +283,7 @@ protocol IRFFDecoderDelegate: AnyObject {
                     self?.displayThread()
                 }
                 operation.queuePriority = .veryHigh
-                operation.qualityOfService = .userInteractive
+                operation.qualityOfService = .userInitiated
                 Self.addDependency(openFileOperation, to: operation)
                 displayOperation = operation
                 Self.enqueue(operation, on: ffmpegOperationQueue)


### PR DESCRIPTION
Fix thread issue:
 
=================================================================
Main Thread Checker: UI API called on a background thread: -[UIView layer]
PID: 32862, TID: 4029972, Thread name: (none), Queue name: render.queue, QoS: 0
Backtrace:
5   Carson.debug.dylib                  0x000000010f7480b0 $s13IRPlayerSwift8IRGLViewC10metalLayer33_69BBC3798091CD1236F087BA5C1CEBEELLSo07CAMetalE0CSgvg + 60
6   Carson.debug.dylib                  0x000000010f74fe84 $s13IRPlayerSwift8IRGLViewC20renderCurrentContent33_69BBC3798091CD1236F087BA5C1CEBEELLyyF + 176
7   Carson.debug.dylib                  0x000000010f74fcd4 $s13IRPlayerSwift8IRGLViewC6renderyyAA14IRFFVideoFrameCSgFyyXEfU_ + 292
8   Carson.debug.dylib                  0x000000010f74d438 $sIg_Ieg_TR + 20
9   Carson.debug.dylib                  0x000000010f74d490 $sIeg_IyB_TR + 24
10  libdispatch.dylib                   0x000000010779d374 _dispatch_client_callout + 12
11  libdispatch.dylib                   0x0000000107793ef4 _dispatch_lane_barrier_sync_invoke_and_complete + 144
12  Carson.debug.dylib                  0x000000010f74fb44 $s13IRPlayerSwift8IRGLViewC6renderyyAA14IRFFVideoFrameCSgF + 316
13  Carson.debug.dylib                  0x000000010f759754 $s13IRPlayerSwift8IRGLViewC4send10videoFrameyAA09IRFFVideoF0C_tF + 80
14  Carson.debug.dylib                  0x000000010f7597b4 $s13IRPlayerSwift8IRGLViewC4send10videoFrameyAA09IRFFVideoF0C_tFTo + 68
15  Carson.debug.dylib                  0x000000010f7cc1c8 $sTa + 20
16  Carson.debug.dylib                  0x000000010f7c8acc $s13IRPlayerSwift14IRFFVideoFrameCIegy_ACIegg_TR + 20
17  Carson.debug.dylib                  0x000000010f7c8828 $s13IRPlayerSwift11IRFFDecoderC13displayThread33_13745F72F18DF1C9FB13A6F37289ABAFLLyyF + 4908
18  Carson.debug.dylib                  0x000000010f7c4d28 $s13IRPlayerSwift11IRFFDecoderC24setupReadPacketOperation33_13745F72F18DF1C9FB13A6F37289ABAFLLyyFyyYbcfU1_ + 152
19  Carson.debug.dylib                  0x000000010f6fa970 $sIegh_IeyBh_TR + 48
20  Foundation                          0x000000018109a920 __NSINDEXSET_IS_CALLING_OUT_TO_A_BOOL_BLOCK__ + 16
21  Foundation                          0x00000001810f69cc -[NSBlockOperation main] + 84
22  Foundation                          0x00000001810f9588 __NSOPERATION_IS_INVOKING_MAIN__ + 12
23  Foundation                          0x00000001810f5d24 -[NSOperation start] + 612
24  Foundation                          0x00000001810f9d8c __NSOPERATIONQUEUE_IS_STARTING_AN_OPERATION__ + 12
25  Foundation                          0x00000001810f99bc __NSOQSchedule_f + 160
26  libdispatch.dylib                   0x00000001077938ac _dispatch_block_async_invoke2 + 104
27  libdispatch.dylib                   0x000000010779d374 _dispatch_client_callout + 12
28  libdispatch.dylib                   0x000000010778724c _dispatch_continuation_pop + 740
29  libdispatch.dylib                   0x00000001077bb5d4 _dispatch_async_redirect_invoke + 728
30  libdispatch.dylib                   0x0000000107796eec _dispatch_root_queue_drain + 564
31  libdispatch.dylib                   0x000000010779793c _dispatch_worker_thread2 + 272
32  libsystem_pthread.dylib             0x00000001079d6bec _pthread_wqthread + 228
33  libsystem_pthread.dylib             0x00000001079d5a28 start_wqthread + 8
Main Thread Checker: UI API called on a background thread: -[UIView layer]
PID: 32862, TID: 4029972, Thread name: (none), Queue name: render.queue, QoS: 0
Backtrace:
5   Carson.debug.dylib                  0x000000010f7480b0 $s13IRPlayerSwift8IRGLViewC10metalLayer33_69BBC3798091CD1236F087BA5C1CEBEELLSo07CAMetalE0CSgvg + 60
6   Carson.debug.dylib                  0x000000010f74fe84 $s13IRPlayerSwift8IRGLViewC20renderCurrentContent33_69BBC3798091CD1236F087BA5C1CEBEELLyyF + 176
7   Carson.debug.dylib                  0x000000010f74fcd4 $s13IRPlayerSwift8IRGLViewC6renderyyAA14IRFFVideoFrameCSgFyyXEfU_ + 292
8   Carson.debug.dylib                  0x000000010f74d438 $sIg_Ieg_TR + 20
9   Carson.debug.dylib                  0x000000010f74d490 $sIeg_IyB_TR + 24
10  libdispatch.dylib                   0x000000010779d374 _dispatch_client_callout + 12
11  libdispatch.dylib                   0x0000000107793ef4 _dispatch_lane_barrier_sync_invoke_and_complete + 144
12  Carson.debug.dylib                  0x000000010f74fb44 $s13IRPlayerSwift8IRGLViewC6renderyyAA14IRFFVideoFrameCSgF + 316
13  Carson.debug.dylib                  0x000000010f759754 $s13IRPlayerSwift8IRGLViewC4send10videoFrameyAA09IRFFVideoF0C_tF + 80
14  Carson.debug.dylib                  0x000000010f7597b4 $s13IRPlayerSwift8IRGLViewC4send10videoFrameyAA09IRFFVideoF0C_tFTo + 68
15  Carson.debug.dylib                  0x000000010f7cc1c8 $sTa + 20
16  Carson.debug.dylib                  0x000000010f7c8acc $s13IRPlayerSwift14IRFFVideoFrameCIegy_ACIegg_TR + 20
17  Carson.debug.dylib                  0x000000010f7c8828 $s13IRPlayerSwift11IRFFDecoderC13displayThread33_13745F72F18DF1C9FB13A6F37289ABAFLLyyF + 4908
18  Carson.debug.dylib                  0x000000010f7c4d28 $s13IRPlayerSwift11IRFFDecoderC24setupReadPacketOperation33_13745F72F18DF1C9FB13A6F37289ABAFLLyyFyyYbcfU1_ + 152
19  Carson.debug.dylib                  0x000000010f6fa970 $sIegh_IeyBh_TR + 48
20  Foundation                          0x000000018109a920 __NSINDEXSET_IS_CALLING_OUT_TO_A_BOOL_BLOCK__ + 16
21  Foundation                          0x00000001810f69cc -[NSBlockOperation main] + 84
22  Foundation                          0x00000001810f9588 __NSOPERATION_IS_INVOKING_MAIN__ + 12
23  Foundation                          0x00000001810f5d24 -[NSOperation start] + 612
24  Foundation                          0x00000001810f9d8c __NSOPERATIONQUEUE_IS_STARTING_AN_OPERATION__ + 12
25  Foundation                          0x00000001810f99bc __NSOQSchedule_f + 160
26  libdispatch.dylib                   0x00000001077938ac _dispatch_block_async_invoke2 + 104
27  libdispatch.dylib                   0x000000010779d374 _dispatch_client_callout + 12
28  libdispatch.dylib                   0x000000010778724c _dispatch_continuation_pop + 740
29  libdispatch.dylib                   0x00000001077bb5d4 _dispatch_async_redirect_invoke + 728
30  libdispatch.dylib                   0x0000000107796eec _dispatch_root_queue_drain + 564
31  libdispatch.dylib                   0x000000010779793c _dispatch_worker_thread2 + 272
32  libsystem_pthread.dylib             0x00000001079d6bec _pthread_wqthread + 228
33  libsystem_pthread.dylib             0x00000001079d5a28 start_wqthread + 8
         HALC_ProxyIOContext.cpp:1623  HALC_ProxyIOContext::IOWorkLoop: skipping cycle due to overload
